### PR TITLE
Feature/campground details

### DIFF
--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -141,6 +141,9 @@ function getCampDetails(clickedCamp) {
           }
 
           // camp name on details page
+          var campNameSubHead = document.getElementById('camp-detail-name');
+          var campTitle = data.data[i].name;
+          campNameSubHead.textContent = campTitle;
 
           // reservation info text
 

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -30,8 +30,6 @@ var campList = document.getElementById('camp-list');
 //ref to camp details container
 var campDetailsContainer = document.getElementById('camp-details-container');
 
-// var for user checkbox: "do you have a campsite picked out yet?"
-//var needCampHelp = 'false';
 
 // --CAMPGROUND API PARAMETERS--
 var campResultsLimit = 25;
@@ -94,7 +92,7 @@ function getCampDetails(clickedCamp) {
           // --CAMP AMENITIES--
           // ref to amenities in the API object
           var amenities = data.data[i].amenities;
-          console.log(amenities);
+          // console.log(amenities);
 
           // trash notes
           var trashNotesEl = document.getElementById('trash-notes');
@@ -126,13 +124,26 @@ function getCampDetails(clickedCamp) {
           // host availability
           var hostEl = document.getElementById('host-notes');
           var hostNotes = amenities.staffOrVolunteerHostOnSite;
-          console.log(hostNotes);
           hostEl.textContent = hostNotes;
           if (hostEl.textContent === '') {
             hostEl.textContent = 'No information available';
           } 
 
-          // Reservation Info
+          // --RESERVATION INFO--
+          // var reservation =  data.data[i].
+
+          // camp description
+          var campDescriptionEl = document.getElementById('camp-info-text');
+          var campNotes = data.data[i].description;
+          campDescriptionEl.textContent = campNotes;
+          if (campDescriptionEl.textContent === '') {
+            campDescriptionEl.textContent = 'Sorry, no reservation information is available for this campsite.'
+          }
+
+          // camp name on details page
+
+          // reservation info text
+
 
           // regulation
 

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -84,12 +84,11 @@ function getCampDetails(clickedCamp) {
       // conditional statement to find correct camp name in the data and display it
       for (let i = 0; i < data.data.length; i++) {
         // ref to the correct info for corresponding camp
-        // TO DO: FIX DATA I REF so it
         var campIndex = data.data[i].name;
         if (clickedCamp === campIndex) {
           console.log('this camp is a match for what you clicked: ' + data.data[i].name);
 
-          //displaythe div when arrow is clicked
+          //display the div when arrow is clicked
           campDetailsContainer.style.display = 'block';
 
           // --CAMP AMENITIES--
@@ -107,6 +106,19 @@ function getCampDetails(clickedCamp) {
           } else {
             trashNotesEl.textContent = trashNotes;
           }
+          
+          // toilets
+          var toiletsEl = document.getElementById('toilet-notes');
+          var toiletNotes = amenities.toilets[0];
+          
+          toiletsEl.textContent = toiletNotes;
+          if (toiletsEl.textContent === '') {
+            toiletsEl.textContent = 'Not available';
+          }
+
+          // Internet
+          
+
         }
       }
     });

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -27,6 +27,8 @@ var apiKey = '9dNeLq2nvcwlctGtvDnExgSlMHam78mtKPhgrnn9';
 var campContainer = document.getElementById('camp-container');
 // ref to camp listing 
 var campList = document.getElementById('camp-list');
+//ref to camp details container
+var campDetailsContainer = document.getElementById('camp-details-container');
 
 // var for user checkbox: "do you have a campsite picked out yet?"
 //var needCampHelp = 'false';
@@ -43,19 +45,54 @@ function clearCampContent() {
 }
 
 $(document).on('click', '.button', function(event) {
-  console.log('Event listener is triggered!');
   event.preventDefault();
+  // ref to clicked arrow's sibling object
   var sibling = $(this).parent().siblings('.content');
-  getCampDetails(sibling);
+   //console.log(sibling);
+
+  // ref to clicked arrow's respective camp name
+  var campName = sibling[0].innerHTML;
+  // pass camp name to display camp details function
+  getCampDetails(campName);
   // var textValue = $(this).siblings('.description').val();
-  // localStorage.setItem(key, textValue);
+  
 });
 
 
 // TODO : FUNCTION FOR DISPLAYING CAMPGROUND DETAILS
-function getCampDetails(clickedElement){
-  console.log(clickedElement);
-  // more code here
+function getCampDetails(clickedCamp){
+  console.log('you clicked on this camp: ' + clickedCamp);
+ 
+  //clear camp details div
+ campDetailsContainer.innerHTML = '';
+  
+ var campDetailsCall = 'https://developer.nps.gov/api/v1/campgrounds?parkCode=' + parkCode + '&api_key=' + apiKey;
+fetch(campDetailsCall)
+.then(function(response){
+  if (!response.ok) {
+    // TODO: we can't use alert windows. if something goes wrong with call we need another way to display it.
+    console.log('api error');
+  } else {
+    return response.json();                       
+  }
+ })
+ .then(function(data){
+  //console.log(data);
+
+  // conditional statement to find correct camp name in the data and display it
+ for (let i = 0; i < data.data.length; i++){
+  if (clickedCamp === data.data[i].name)
+  console.log('this camp is a match for what you clicked: ' + data.data[i].name);
+
+   // --CAMP DETAILS--
+
+  
+ }
+
+ });
+
+  // TO DO: set my campsite to local storage
+  // localStorage.setItem(key, textValue);
 }
 
 function generateCampList(parkCode, apiKey) {
@@ -75,8 +112,8 @@ function generateCampList(parkCode, apiKey) {
   }
  })
  .then(function(data){
-  console.log(data);
-  console.log(data.data[0].name); // good
+  //console.log(data);
+  //console.log(data.data[0].name); // good
   // --CAMP LISTINGS--
   for (let i = 0; i < data.data.length; i++) {
     // div class .item

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -58,42 +58,63 @@ $(document).on('click', '.button', function(event) {
   
 });
 
+// TODO: make function for displaying/hiding campground details div
+
 
 // TODO : FUNCTION FOR DISPLAYING CAMPGROUND DETAILS
-function getCampDetails(clickedCamp){
+function getCampDetails(clickedCamp) {
   console.log('you clicked on this camp: ' + clickedCamp);
- 
+
   //clear camp details div
- campDetailsContainer.innerHTML = '';
-  
- var campDetailsCall = 'https://developer.nps.gov/api/v1/campgrounds?parkCode=' + parkCode + '&api_key=' + apiKey;
-fetch(campDetailsCall)
-.then(function(response){
-  if (!response.ok) {
-    // TODO: we can't use alert windows. if something goes wrong with call we need another way to display it.
-    console.log('api error');
-  } else {
-    return response.json();                       
-  }
- })
- .then(function(data){
-  //console.log(data);
+  // campDetailsContainer.innerHTML = '';
 
-  // conditional statement to find correct camp name in the data and display it
- for (let i = 0; i < data.data.length; i++){
-  if (clickedCamp === data.data[i].name)
-  console.log('this camp is a match for what you clicked: ' + data.data[i].name);
+  var campDetailsCall = 'https://developer.nps.gov/api/v1/campgrounds?parkCode=' + parkCode + '&api_key=' + apiKey;
+  fetch(campDetailsCall)
+    .then(function (response) {
+      if (!response.ok) {
+        // TODO: we can't use alert windows. if something goes wrong with the call we need another way to display it.
+        console.log('api error');
+      } else {
+        return response.json();
+      }
+    })
+    .then(function (data) {
+      console.log(data);
 
-   // --CAMP DETAILS--
+      // conditional statement to find correct camp name in the data and display it
+      for (let i = 0; i < data.data.length; i++) {
+        // ref to the correct info for corresponding camp
+        // TO DO: FIX DATA I REF so it
+        var campIndex = data.data[i].name;
+        if (clickedCamp === campIndex) {
+          console.log('this camp is a match for what you clicked: ' + data.data[i].name);
 
-  
- }
+          //displaythe div when arrow is clicked
+          campDetailsContainer.style.display = 'block';
 
- });
+          // --CAMP AMENITIES--
+          // ref to amenities in the API object
+          var amenities = data.data[i].amenities;
+          console.log(amenities);
+
+          // trash notes
+          var trashNotesEl = document.getElementById('trash-notes');
+          var trashNotes = amenities.trashRecyclingCollection;
+         
+          if (trashNotes === '') {
+            trashNotesEl.textContent = 'Not available.';
+
+          } else {
+            trashNotesEl.textContent = trashNotes;
+          }
+        }
+      }
+    });
 
   // TO DO: set my campsite to local storage
   // localStorage.setItem(key, textValue);
 }
+
 
 function generateCampList(parkCode, apiKey) {
   // clear content if nes

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -149,12 +149,10 @@ function getCampDetails(clickedCamp) {
           // reservation info text below description
           var campReservationInfoEl = document.getElementById('reservation-notes');
           var campResNotes = data.data[i].reservationInfo;
-          console.log(campResNotes)
           campReservationInfoEl.textContent = campResNotes;
-          // to do: if empty, make p el go away
           //to do: if duplicate paragraph, make it disappear
 
-          //how to reserve link  OR 
+          //how to reserve link 
           var campHowToResEl = document.getElementById('how-to-reserve');
           var howToResNotes = data.data[i].reservationUrl;
           campHowToResEl.textContent = howToResNotes;
@@ -162,10 +160,20 @@ function getCampDetails(clickedCamp) {
           if (campHowToResEl.textContent === '') {
             campHowToResEl.textContent = 'No reservation URL available. Check the Reservation info above for details.'
           }
+          campHowToResEl.style.padding = '10px';
 
+          // regulations
+          var campRegulationsEl = document.getElementById('camp-regulations-text');
+          var regulationNotes = data.data[i].regulationsOverview;
+          campRegulationsEl.textContent = regulationNotes;
+          
+          var campRegUrlEl = document.getElementById('regulations-url');
+          var campRegUrl = data.data[i].regulationsurl;
+          campRegUrlEl.textContent = campRegUrl;
 
-          //contacts
-
+          if (campRegulationsEl.textContent === '' && campRegUrlEl.textContent === ''){
+            campRegulationsEl.textContent = 'No regulation information available.'
+          }
 
         }
       }

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -101,7 +101,7 @@ function getCampDetails(clickedCamp) {
           var trashNotes = amenities.trashRecyclingCollection;
          
           if (trashNotes === '') {
-            trashNotesEl.textContent = 'Not available.';
+            trashNotesEl.textContent = 'None';
 
           } else {
             trashNotesEl.textContent = trashNotes;
@@ -113,11 +113,30 @@ function getCampDetails(clickedCamp) {
           
           toiletsEl.textContent = toiletNotes;
           if (toiletsEl.textContent === '') {
-            toiletsEl.textContent = 'Not available';
+            toiletsEl.textContent = 'None';
           }
 
-          // Internet
-          
+          // cell reception
+          var receptionEl = document.getElementById('reception-notes');
+          var receptionNotes = amenities.cellPhoneReception;
+          receptionEl.textContent = receptionNotes;
+          if (receptionEl.textContent === '') {
+            receptionEl.textContent = 'No information available';
+          }
+          // host availability
+          var hostEl = document.getElementById('host-notes');
+          var hostNotes = amenities.staffOrVolunteerHostOnSite;
+          console.log(hostNotes);
+          hostEl.textContent = hostNotes;
+          if (hostEl.textContent === '') {
+            hostEl.textContent = 'No information available';
+          } 
+
+          // Reservation Info
+
+          // regulation
+
+          //contacts
 
         }
       }

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -32,10 +32,10 @@ var campDetailsContainer = document.getElementById('camp-details-container');
 
 
 // --CAMPGROUND API PARAMETERS--
-var campResultsLimit = 25;
+var campResultsLimit = 15;
 // TO DO: Get park code from user response
 //var parkName = document.getElementById("park-input").value;
-var parkCode = 'care';
+var parkCode = 'dena';
 
 
 function clearCampContent() {
@@ -145,12 +145,27 @@ function getCampDetails(clickedCamp) {
           var campTitle = data.data[i].name;
           campNameSubHead.textContent = campTitle;
 
-          // reservation info text
 
+          // reservation info text below description
+          var campReservationInfoEl = document.getElementById('reservation-notes');
+          var campResNotes = data.data[i].reservationInfo;
+          console.log(campResNotes)
+          campReservationInfoEl.textContent = campResNotes;
+          // to do: if empty, make p el go away
+          //to do: if duplicate paragraph, make it disappear
 
-          // regulation
+          //how to reserve link  OR 
+          var campHowToResEl = document.getElementById('how-to-reserve');
+          var howToResNotes = data.data[i].reservationUrl;
+          campHowToResEl.textContent = howToResNotes;
+          // to do: make link be hyperlink
+          if (campHowToResEl.textContent === '') {
+            campHowToResEl.textContent = 'No reservation URL available. Check the Reservation info above for details.'
+          }
+
 
           //contacts
+
 
         }
       }

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -29,7 +29,9 @@ var campContainer = document.getElementById('camp-container');
 var campList = document.getElementById('camp-list');
 //ref to camp details container
 var campDetailsContainer = document.getElementById('camp-details-container');
-
+// these containers are hidden unless 'I need help" checkbox is clicked
+campDetailsContainer.style.display = 'none';
+campContainer.style.display = 'none';
 
 // --CAMPGROUND API PARAMETERS--
 var campResultsLimit = 15;
@@ -62,7 +64,7 @@ $(document).on('click', '.button', function(event) {
 // TODO : FUNCTION FOR DISPLAYING CAMPGROUND DETAILS
 function getCampDetails(clickedCamp) {
   console.log('you clicked on this camp: ' + clickedCamp);
-
+  campDetailsContainer.style.display = 'block';
   //clear camp details div
   // campDetailsContainer.innerHTML = '';
 
@@ -269,6 +271,7 @@ findOnMyOwnCheckbox.addEventListener('change', function (event) {
           findHelpCheckbox.checked = false; // Uncheck the other checkbox
       }
       campContainer.style.display = 'none';
+      campDetailsContainer.style.display = 'none';
   } else {
       // "I will find it on my own" checkbox is unchecked
       

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
         <div id="camp-details-container" class="ui container half orange-bckg olv-bord blk-txt">
 
             <h2>Campground Details</h2>
+            <h3 id="camp-detail-name"></h3>
             
 
             <div class="ui grid center aligned">

--- a/index.html
+++ b/index.html
@@ -129,18 +129,13 @@
                                 <div class="description" id="host-notes"></div>
                             </div>
                         </div>
-                        
                     </div>
                 </div>
 
                 <div class="ten wide column grey-bckg pd-sm mg-med">
                     <div id="reservation-div">
                         <h2>Reservation Info</h2>
-                         <!-- <p>
-                        Lava Point Campground is typically open May through September, as weather allows. 
-                        Situated at 7890 feet above sea level, it is off the Kolob Terrace Road, 25 miles (45 minutes) north of the town of Virgin. 
-                        It takes approximately 1 hour 20 minutes to drive to the campground from the South Entrance of Zion Canyon.
-                         </p> -->
+                         <p id="camp-info-text"></p>
                     </div> 
                     <div id="regulations-div">     
                         <h4>Regulations</h4>

--- a/index.html
+++ b/index.html
@@ -145,13 +145,9 @@
                     <div id="regulations-div">     
                         <h4>Regulations</h4>
                         <p id="camp-regulations-text"></p>
-                    </div>  
-                    <div id="camp-contacts-div">  
-                        <h4>Contacts</h4>
-                        <!-- <p>
-                        park contacts
-                        </p> -->
-                    </div>    
+                        <br>
+                        <p id="regulations-url"></p>
+                    </div>     
                 </div>
 
                 <button class="ui button olv-btn mg-btm-sm">I have reserved this site, save to My Campsite</button>

--- a/index.html
+++ b/index.html
@@ -115,9 +115,21 @@
                                 <div class="description" id="toilet-notes"></div>
                             </div>
                         </div>
-                        <div class="item">Internet</div>
-                        <div class="item">Host on site?</div>
-                        <div class="item">Items available for sale here:</div>
+                        <div class="item">
+                            <i class="right triangle icon"></i>
+                            <div class="content">
+                                <div class="header">Cell Reception</div>
+                                <div class="description" id="reception-notes"></div>
+                            </div>
+                        </div>
+                        <div class="item">
+                            <i class="right triangle icon"></i>
+                            <div class="content">
+                                <div class="header">Host on site?</div>
+                                <div class="description" id="host-notes"></div>
+                            </div>
+                        </div>
+                        
                     </div>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -108,7 +108,13 @@
                                 <div class="description" id="trash-notes"></div>
                             </div>
                         </div>
-                        <div class="item">Toilets</div>
+                        <div class="item">
+                            <i class="right triangle icon"></i>
+                            <div class="content">
+                                <div class="header">Restroom Info</div>
+                                <div class="description" id="toilet-notes"></div>
+                            </div>
+                        </div>
                         <div class="item">Internet</div>
                         <div class="item">Host on site?</div>
                         <div class="item">Items available for sale here:</div>

--- a/index.html
+++ b/index.html
@@ -137,17 +137,14 @@
                     <div id="reservation-div">
                         <h2>Reservation Info</h2>
                          <p id="camp-info-text"></p>
+                         <br>
+                         <p id="reservation-notes"></p>
+                         <h4>How to Reserve:</h4>
+                         <p id="how-to-reserve"></p>
                     </div> 
                     <div id="regulations-div">     
                         <h4>Regulations</h4>
-                        <!-- <p>
-                        Vehicles longer than 19 feet are not permitted on the road to the campground. 
-                        Store your food in a vehicle or a hard-sided lockable container. 
-                        Do not feed wildlife. Do not leave trash unattended. 
-                        Please dispose of trash in dumpsters. 
-                        Lava Point campground cannot be included in the itinerary of any Wilderness backpacking trips. 
-                        If you are planning a backpacking traverse hike (going from Kolob Canyons south and across Zion Canyon) you need to make reservations for each night in designated Wilderness campsites and camp areas.
-                        </p> -->
+                        <p id="camp-regulations-text"></p>
                     </div>  
                     <div id="camp-contacts-div">  
                         <h4>Contacts</h4>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
         <br/>
         
-        <div class="ui container half orange-bckg olv-bord blk-txt">
+        <div id="camp-details-container" class="ui container half orange-bckg olv-bord blk-txt">
 
             <h2>Campground Details</h2>
             <h3 id="camp-name">Idfk lol</h3>

--- a/index.html
+++ b/index.html
@@ -94,14 +94,20 @@
         <div id="camp-details-container" class="ui container half orange-bckg olv-bord blk-txt">
 
             <h2>Campground Details</h2>
-            <h3 id="camp-name">Idfk lol</h3>
+            
 
             <div class="ui grid center aligned">
 
                 <div class="four wide column grey-bckg pd-sm mg-med">
                     <h2>Amenities</h2>
                     <div class="ui list">
-                        <div class="item">Trash Collection</div>
+                        <div class="item">
+                            <i class="right triangle icon"></i>
+                            <div class="content">
+                                <div class="header">Trash Collection</div>
+                                <div class="description" id="trash-notes"></div>
+                            </div>
+                        </div>
                         <div class="item">Toilets</div>
                         <div class="item">Internet</div>
                         <div class="item">Host on site?</div>
@@ -110,29 +116,31 @@
                 </div>
 
                 <div class="ten wide column grey-bckg pd-sm mg-med">
-                    <h2>Reservation Info</h2>
-                    <p>
+                    <div id="reservation-div">
+                        <h2>Reservation Info</h2>
+                         <!-- <p>
                         Lava Point Campground is typically open May through September, as weather allows. 
                         Situated at 7890 feet above sea level, it is off the Kolob Terrace Road, 25 miles (45 minutes) north of the town of Virgin. 
                         It takes approximately 1 hour 20 minutes to drive to the campground from the South Entrance of Zion Canyon.
-                    </p>
-                    <h4>
-                        Regulations
-                    </h4>
-                    <p>
+                         </p> -->
+                    </div> 
+                    <div id="regulations-div">     
+                        <h4>Regulations</h4>
+                        <!-- <p>
                         Vehicles longer than 19 feet are not permitted on the road to the campground. 
                         Store your food in a vehicle or a hard-sided lockable container. 
                         Do not feed wildlife. Do not leave trash unattended. 
                         Please dispose of trash in dumpsters. 
                         Lava Point campground cannot be included in the itinerary of any Wilderness backpacking trips. 
                         If you are planning a backpacking traverse hike (going from Kolob Canyons south and across Zion Canyon) you need to make reservations for each night in designated Wilderness campsites and camp areas.
-                    </p>
-                    <h4>
-                        Contacts
-                    </h4>
-                    <p>
+                        </p> -->
+                    </div>  
+                    <div id="camp-contacts-div">  
+                        <h4>Contacts</h4>
+                        <!-- <p>
                         park contacts
-                    </p>
+                        </p> -->
+                    </div>    
                 </div>
 
                 <button class="ui button olv-btn mg-btm-sm">I have reserved this site, save to My Campsite</button>


### PR DESCRIPTION
display logic for both camp divs based on checkboxes.
displays camp details for each campground
max results count for campgrounds is currently 15. we would need a dynamic page generator to get more.
removed camp contacts section in the details because its almost always empty or a generic info email for the whole park.
if we have time:
make generated links for reservations and regulations.